### PR TITLE
Add parachins tests to pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ typings/
 
 /dist/
 yarn.lock
+
+.GITLAB_DEPLOY_TOKEN

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,6 +85,7 @@ test-current-latest-container-image:
     - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
+    - pwd ; ls -la
     - gurke/scripts/run-test-environment-manager.sh  \
         --test-script=../../simnet/testing/parachains/run_tests.sh \
         --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,10 +103,12 @@ test-pr-container-image:
   variables:
     IMAGE_UNDER_TEST:              "paritypr/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "${CI_COMMIT_SHORT_SHA}"
-    PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
+    # use parity/polkadot as default until we will have paritypr/synth-wave:master
+    PARACHAINS_IMAGE:              "docker.io/parity/polkadot"
+    # PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
     # there is no master tag for docker.io/paritypr/synth-wave
     # Error response from daemon: manifest for paritypr/synth-wave:master not found: manifest unknown: manifest unknown
-    PARACHAINS_IMAGE_TAG:          "2714"
+    PARACHAINS_IMAGE_TAG:          "master"
     COLLATOR_IMAGE:                "docker.io/paritypr/colander"
     COLLATOR_IMAGE_TAG:            "master"
   image:                           "${IMAGE_UNDER_TEST}:${IMAGE_UNDER_TEST_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - build
+  - test
   - post-merge
 
 
@@ -58,24 +59,35 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
   after_script:
     - podman logout docker.io
 
-
-  # TODO: How to test that image is good
-      # test-simnetscripts-image:
-      #   variables:
-      #     <<:                            *global-vars
-      #   variables:
-      #     CONTAINER_IMAGE:               paritypr/simnetscripts
-      #   image:                           "${CONTAINER_IMAGE}:${CI_COMMIT_SHORT_SHA}"
-      #   interruptible:                   true
-      #   stage:                           post-build
-      #   tags:
-      #     - parity-simnetscripts
-      #   needs:
-      #     - job:                         build-simnetscripts-image-and-push-temporarly-in-paritypr
-      #   script:
-      #     - echo "LOG INFO step 6 test image ${CONTAINER_IMAGE}:${CI_COMMIT_SHORT_SHA} "
-      #     - /home/nonroot/gurke/scripts/run-test-environment-manager.sh -t run-external-tool-test.sh
-      #   retry: 2
+parachains-full-test-set:          &parachains-tests
+  tags:
+    - parity-simnetscripts-build
+  stage:                           test
+  image:                           quay.io/podman/stable
+  interruptible:                   true
+  variables:
+    # IMAGE_NAME:                docker.io/parity/rococo
+    IMAGE_NAME:                "docker.io/paritypr/synth-wave"
+    # IMAGE_TAG:                 rococo-v1
+    IMAGE_TAG:                 master
+    COLLATOR_IMAGE_TAG:                 master
+    # COLLATOR_IMAGE_TAG:        master
+  before_script:
+    - echo "'${CI_PIPELINE_SOURCE}' type trigger."
+    - echo "Image under test '${IMAGE_NAME}:${IMAGE_TAG}'."
+    - echo "Collator image 'docker.io/paritypr/colander:${COLLATOR_IMAGE_TAG}'."
+    - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
+        ( echo "No docker credentials provided"; exit 1 )
+  script:
+    - podman pull "docker.io/paritytech/simnetscripts:latest"
+    - podman pull "${IMAGE_NAME}:${IMAGE_TAG}"
+    - podman run
+           --volume "$(pwd)"/testing:/home/nonroot/gurke/testing
+           --volume /etc/gurke/:/etc/gurke/
+           paritytech/simnetscripts:latest
+                  scripts/run-test-environment-manager.sh
+                   --test-script=../testing/parachains/run_tests.sh
+                   --image="${IMAGE_NAME}:${IMAGE_TAG}"
 
 push-simnetscripts-image-to-paritytech:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 stages:
   - build
   - test
-  - post-merge
+  - update-container-image-latest
 
 
 variables:                         &global-vars
@@ -15,17 +15,18 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
     - parity-simnetscripts-build
   variables:
     # random name to replace simnetscripts until we will have private docker repo 
-    CONTAINER_IMAGE:               paritypr/simnetscripts
+    CONTAINER_IMAGE:               "paritypr/simnetscripts"
+    CONTAINER_IMAGE_TAG:           "${CI_COMMIT_SHORT_SHA}" 
   stage:                           build
   before_script:
-    - echo "Working with $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
-    - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
+    - echo "Image that will be built ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}"
+    - test "${DOCKER_SIMNET_USER}" -a "${DOCKER_SIMNET_PASS}" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
     - |
-      echo "LOG INFO step 4 build container image $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
-      echo "$DOCKER_SIMNET_PASS" \
-           | podman login --username "$DOCKER_SIMNET_USER" --password-stdin docker.io
+      echo "LOG INFO building container ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}"
+      echo "${DOCKER_SIMNET_PASS}" \
+           | podman login --username "${DOCKER_SIMNET_USER}" --password-stdin docker.io
       whoami
       podman info
       df -h | grep /var/lib/containers
@@ -38,80 +39,112 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
         quay.io/buildah/stable \
             buildah bud  \
               --layers=true  \
-              --cache-from  "$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA" \
-              --tag         "$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA" \
+              --cache-from  "${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}" \
+              --tag         "${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}" \
               /build 
-      echo "LOG INFO step 5 image $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA built successfully"
+      echo "LOG INFO image ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG} built successfully"
       echo "$DOCKER_SIMNET_PASS" \
            | podman  login --username "$DOCKER_SIMNET_USER" --password-stdin docker.io
       podman push --format=v2s2 "$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
-      echo "LOG INFO step 6 image $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA pushed successfully"
+      echo "LOG INFO ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG} pushed successfully"
       echo "LOG check if need to cleanup dangling images"
       df -h | grep /var/lib/containers
       CACHE_USE_PERCENT="$(df -h | grep -vE '/var/lib/containers/.*' | grep /var/lib/containers | awk '{print $5}' | sed 's/%//g')"
-      test -n "$CACHE_USE_PERCENT" \
+      test -n "${CACHE_USE_PERCENT}" \
               || ( echo "This variable can't be emtpy" ; exit 1 )
-      if test "$CACHE_USE_PERCENT" -ge 80 ; then 
-        echo "LOG INFO need to cleanup cache, value: $CACHE_USE_PERCENT"
+      if test "${CACHE_USE_PERCENT}" -ge 80 ; then 
+        echo "LOG INFO need to cleanup cache, value: ${CACHE_USE_PERCENT}"
         time podman rmi -f $(podman images -q -f "dangling=true")
       else 
-        echo "LOG INFO No Cleanup needed this time value: $CACHE_USE_PERCENT"
+        echo "LOG INFO No Cleanup needed this time value: ${CACHE_USE_PERCENT}"
       fi
   retry: 1
   after_script:
     - podman logout docker.io
 
-parachains-full-test-set:          &parachains-tests
+test-current-latest-container-image:
+  stage:                           build
   tags:
-    - parity-simnetscripts-build
-  stage:                           test
-  image:                           quay.io/podman/stable
-  interruptible:                   true
+    - parity-simnetscripts
   variables:
-    IMAGE_NAME:                    "docker.io/paritypr/synth-wave"
-    IMAGE_TAG:                     master
-    COLLATOR_IMAGE_TAG:            master
+    IMAGE_UNDER_TEST:              "paritytech/simnetscripts"
+    IMAGE_UNDER_TEST_TAG:          "latest"
+    PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
+    # there is no master tag for docker.io/paritypr/synth-wave
+    # Error response from daemon: manifest for paritypr/synth-wave:master not found: manifest unknown: manifest unknown
+    PARACHAINS_IMAGE_TAG:          "2714"
+    COLLATOR_IMAGE:                "docker.io/paritypr/colander"
+    COLLATOR_IMAGE_TAG:            "master"
+  image:                           "${IMAGE_UNDER_TEST}:${IMAGE_UNDER_TEST_TAG}"
+  interruptible:                    true
   before_script:
     - echo "'${CI_PIPELINE_SOURCE}' type trigger."
-    - echo "Image under test '$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
-    - echo "Collator image 'docker.io/paritypr/colander:${COLLATOR_IMAGE_TAG}'."
+    - echo "Image under test '${IMAGE_UNDER_TEST}:${IMAGE_UNDER_TEST_TAG}'"
+    - echo "Parachians image '${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}'."
+    - echo "Collator image   '${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}'."
     - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
-    - podman pull "docker.io/paritytech/simnetscripts:latest"
-    - podman pull "${IMAGE_NAME}:${IMAGE_TAG}"
-    - podman run
-           --volume "$(pwd)"/testing:/home/nonroot/gurke/testing
-           --volume /etc/gurke/:/etc/gurke/
-           $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA
-                  scripts/run-test-environment-manager.sh
-                   --test-script=../testing/parachains/run_tests.sh
-                   --image="${IMAGE_NAME}:${IMAGE_TAG}"
+    - gurke/scripts/run-test-environment-manager.sh  \
+        --test-script=../../simnet/testing/parachains/run_tests.sh \
+        --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
+        --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
 
-push-simnetscripts-image-to-paritytech:
+test-pr-container-image:          
+  tags:
+    - parity-simnetscripts
+  stage:                           test
+  interruptible:                   true
+  variables:
+    IMAGE_UNDER_TEST:              "paritypr/simnetscripts"
+    IMAGE_UNDER_TEST_TAG:          "${CI_COMMIT_SHORT_SHA}"
+    PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
+    # there is no master tag for docker.io/paritypr/synth-wave
+    # Error response from daemon: manifest for paritypr/synth-wave:master not found: manifest unknown: manifest unknown
+    PARACHAINS_IMAGE_TAG:          "2714"
+    COLLATOR_IMAGE:                "docker.io/paritypr/colander"
+    COLLATOR_IMAGE_TAG:            "master"
+  image:                           "${IMAGE_UNDER_TEST}:${IMAGE_UNDER_TEST_TAG}"
+  before_script:
+    - echo "Trigger type     ${CI_PIPELINE_SOURCE}'"
+    - echo "Image under test '${IMAGE_UNDER_TEST}:${IMAGE_UNDER_TEST_TAG}"
+    - echo "Parachians image '${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}'."
+    - echo "Collator image   '${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}'."
+    - test "${DOCKER_SIMNET_USER}" -a "${DOCKER_SIMNET_PASS}" ||
+        ( echo "No docker credentials provided"; exit 1 )
+  script:
+    - gurke/scripts/run-test-environment-manager.sh  \
+        --test-script=../../simnet/testing/parachains/run_tests.sh \
+        --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
+        --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
+
+update-latest-container-image:
   variables:
     <<:                            *global-vars
-    UPSTREAM_BUILD_TRIGGER:        $BUILD_SIMNETSCRIPTS
-  stage:                           post-merge
-#  needs:
-#    - job:                         test-simnetscripts-image
-  image:                           quay.io/buildah/stable
+    UPSTREAM_BUILD_TRIGGER:        ${BUILD_SIMNETSCRIPTS}
+    PR_IMAGE:                      "paritypr/simnetscripts"
+    PR_IMAGE_TAG:                  "${CI_COMMIT_SHORT_SHA}"           
+    PUSH_IMAGE:                    "paritytech/simnetscripts"
+    PUSH_IMAGE_TAG:                "latest"
+  stage:                            update-container-image-latest
+  needs:
+    - job:                          test-pr-container-image
+  image:                            quay.io/buildah/stable
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
     - if: '$UPSTREAM_BUILD_TRIGGER == "true"'
   tags:
-    - parity-simnetscripts-build
+    - parity-simnetscripts
   before_script:
-    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+    - test "${Docker_Hub_User_Parity}" -a "${Docker_Hub_Pass_Parity}" ||
         ( echo "no docker credentials provided"; exit 1 )
   script:
-    - echo "LOG INFO step 7 update paritytech/simnetscripts:latest"
-    - echo "$Docker_Hub_Pass_Parity" |
-        buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - echo "LOG INFO pushing latest image  ${PUSH_IMAGE}:${PUSH_IMAGE_TAG}"
+    - echo "${Docker_Hub_Pass_Parity}" |
+        buildah login --username "${Docker_Hub_User_Parity}" --password-stdin docker.io
     - buildah info
-    - 'buildah pull "paritypr/simnetscripts:$CI_COMMIT_SHORT_SHA"'
-    - 'buildah tag "paritypr/simnetscripts:$CI_COMMIT_SHORT_SHA" paritytech/simnetscripts:latest'
-    - 'buildah push --format=v2s2 paritytech/simnetscripts:latest'
+    - 'buildah pull "${PR_IMAGE}:${PR_IMAGE_TAG}"'
+    - 'buildah tag "${PR_IMAGE}:${PR_IMAGE_TAG}" "${PUSH_IMAGE}:${PUSH_IMAGE_TAG}"'
+    - 'buildah push --format=v2s2 "${PUSH_IMAGE}:${PUSH_IMAGE_TAG}"'
   after_script:
     - buildah logout docker.io
-# dummy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,11 +77,10 @@ test-current-latest-container-image:
     - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
-    - cd /home/nonroot/gurke/scripts/
-    - ./run-test-environment-manager.sh  
-        --test-script=../simnet/testing/parachains/run_tests.sh 
-        --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" 
-        --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
+    -  /home/nonroot/gurke/scripts/run-test-environment-manager.sh  
+          --test-script=../../simnet/testing/parachains/run_tests.sh 
+          --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" 
+          --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
   allow_failure: true
 
 test-pr-container-image:          

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,9 +86,9 @@ test-current-latest-container-image:
         ( echo "No docker credentials provided"; exit 1 )
   script:
     - cd /home/nonroot/gurke/scripts/
-    - ./run-test-environment-manager.sh  \
-        --test-script=../../simnet/testing/parachains/run_tests.sh \
-        --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
+    - ./run-test-environment-manager.sh  
+        --test-script=../../simnet/testing/parachains/run_tests.sh 
+        --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" 
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
 
 test-pr-container-image:          
@@ -117,9 +117,9 @@ test-pr-container-image:
         ( echo "No docker credentials provided"; exit 1 )
   script:
     - cd /home/nonroot/gurke/scripts/
-    - ./run-test-environment-manager.sh  \
-        --test-script=../../simnet/testing/parachains/run_tests.sh \
-        --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
+    - ./run-test-environment-manager.sh  
+        --test-script=../../simnet/testing/parachains/run_tests.sh 
+        --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" 
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
 
 update-latest-container-image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
     CONTAINER_IMAGE:               paritypr/simnetscripts
   stage:                           build
   before_script:
+    - echo "Working with $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
     - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
@@ -28,6 +29,7 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
       whoami
       podman info
       df -h | grep /var/lib/containers
+      echo "${GITLAB_DEPLOY_TOKEN}" > .GITLAB_DEPLOY_TOKEN
       time podman run \
         --volume .:/build  \
         --volume /var/lib/containers/:/var/lib/containers \
@@ -66,15 +68,12 @@ parachains-full-test-set:          &parachains-tests
   image:                           quay.io/podman/stable
   interruptible:                   true
   variables:
-    # IMAGE_NAME:                docker.io/parity/rococo
-    IMAGE_NAME:                "docker.io/paritypr/synth-wave"
-    # IMAGE_TAG:                 rococo-v1
-    IMAGE_TAG:                 master
-    COLLATOR_IMAGE_TAG:                 master
-    # COLLATOR_IMAGE_TAG:        master
+    IMAGE_NAME:                    "docker.io/paritypr/synth-wave"
+    IMAGE_TAG:                     master
+    COLLATOR_IMAGE_TAG:            master
   before_script:
     - echo "'${CI_PIPELINE_SOURCE}' type trigger."
-    - echo "Image under test '${IMAGE_NAME}:${IMAGE_TAG}'."
+    - echo "Image under test '$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
     - echo "Collator image 'docker.io/paritypr/colander:${COLLATOR_IMAGE_TAG}'."
     - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
         ( echo "No docker credentials provided"; exit 1 )
@@ -84,7 +83,7 @@ parachains-full-test-set:          &parachains-tests
     - podman run
            --volume "$(pwd)"/testing:/home/nonroot/gurke/testing
            --volume /etc/gurke/:/etc/gurke/
-           paritytech/simnetscripts:latest
+           $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA
                   scripts/run-test-environment-manager.sh
                    --test-script=../testing/parachains/run_tests.sh
                    --image="${IMAGE_NAME}:${IMAGE_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ test-current-latest-container-image:
         ( echo "No docker credentials provided"; exit 1 )
   script:
     - pwd ; ls -la
-    - gurke/scripts/run-test-environment-manager.sh  \
+    - /home/nonroot/gurke/scripts/run-test-environment-manager.sh  \
         --test-script=../../simnet/testing/parachains/run_tests.sh \
         --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
@@ -116,7 +116,7 @@ test-pr-container-image:
     - test "${DOCKER_SIMNET_USER}" -a "${DOCKER_SIMNET_PASS}" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
-    - gurke/scripts/run-test-environment-manager.sh  \
+    - /home/nonroot/gurke/scripts/run-test-environment-manager.sh  \
         --test-script=../../simnet/testing/parachains/run_tests.sh \
         --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,12 +19,12 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
     CONTAINER_IMAGE_TAG:           "${CI_COMMIT_SHORT_SHA}" 
   stage:                           build
   before_script:
-    - echo "Image that will be built ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}"
+    - echo "Image that will be built ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}"
     - test "${DOCKER_SIMNET_USER}" -a "${DOCKER_SIMNET_PASS}" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
     - |
-      echo "LOG INFO building container ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}"
+      echo "LOG INFO building container ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}"
       echo "${DOCKER_SIMNET_PASS}" \
            | podman login --username "${DOCKER_SIMNET_USER}" --password-stdin docker.io
       whoami
@@ -39,14 +39,14 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
         quay.io/buildah/stable \
             buildah bud  \
               --layers=true  \
-              --cache-from  "${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}" \
-              --tag         "${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG}" \
+              --cache-from  "${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}" \
+              --tag         "${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}" \
               /build 
-      echo "LOG INFO image ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG} built successfully"
+      echo "LOG INFO image ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG} built successfully"
       echo "$DOCKER_SIMNET_PASS" \
            | podman  login --username "$DOCKER_SIMNET_USER" --password-stdin docker.io
-      podman push --format=v2s2 "$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
-      echo "LOG INFO ${CONTAINER_IMAGE}:${COLLATOR_IMAGE_TAG} pushed successfully"
+      podman push --format=v2s2 "$CONTAINER_IMAGE:$CONTAINER_IMAGE_TAG"
+      echo "LOG INFO ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG} pushed successfully"
       echo "LOG check if need to cleanup dangling images"
       df -h | grep /var/lib/containers
       CACHE_USE_PERCENT="$(df -h | grep -vE '/var/lib/containers/.*' | grep /var/lib/containers | awk '{print $5}' | sed 's/%//g')"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,8 +85,8 @@ test-current-latest-container-image:
     - test "$DOCKER_SIMNET_USER" -a "$DOCKER_SIMNET_PASS" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
-    - pwd ; ls -la
-    - /home/nonroot/gurke/scripts/run-test-environment-manager.sh  \
+    - cd /home/nonroot/gurke/scripts/
+    - ./run-test-environment-manager.sh  \
         --test-script=../../simnet/testing/parachains/run_tests.sh \
         --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
@@ -116,7 +116,8 @@ test-pr-container-image:
     - test "${DOCKER_SIMNET_USER}" -a "${DOCKER_SIMNET_PASS}" ||
         ( echo "No docker credentials provided"; exit 1 )
   script:
-    - /home/nonroot/gurke/scripts/run-test-environment-manager.sh  \
+    - cd /home/nonroot/gurke/scripts/
+    - ./run-test-environment-manager.sh  \
         --test-script=../../simnet/testing/parachains/run_tests.sh \
         --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" \
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,10 +69,12 @@ test-current-latest-container-image:
   variables:
     IMAGE_UNDER_TEST:              "paritytech/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "latest"
-    PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
+    # use parity/polkadot as default until we will have paritypr/synth-wave:master
+    PARACHAINS_IMAGE:              "docker.io/parity/polkadot"
+    # PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
     # there is no master tag for docker.io/paritypr/synth-wave
     # Error response from daemon: manifest for paritypr/synth-wave:master not found: manifest unknown: manifest unknown
-    PARACHAINS_IMAGE_TAG:          "2714"
+    PARACHAINS_IMAGE_TAG:          "master"
     COLLATOR_IMAGE:                "docker.io/paritypr/colander"
     COLLATOR_IMAGE_TAG:            "master"
   image:                           "${IMAGE_UNDER_TEST}:${IMAGE_UNDER_TEST_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ test-current-latest-container-image:
   script:
     - cd /home/nonroot/gurke/scripts/
     - ./run-test-environment-manager.sh  
-        --test-script=../../simnet/testing/parachains/run_tests.sh 
+        --test-script=../simnet/testing/parachains/run_tests.sh 
         --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" 
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ test-current-latest-container-image:
   variables:
     IMAGE_UNDER_TEST:              "paritytech/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "latest"
-    PARACHAINS_IMAGE:              "docker.io/parity/synth-wave"
+    PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
     PARACHAINS_IMAGE_TAG:          "master"
     COLLATOR_IMAGE:                "docker.io/paritypr/colander"
     COLLATOR_IMAGE_TAG:            "master"
@@ -93,7 +93,7 @@ test-pr-container-image:
   variables:
     IMAGE_UNDER_TEST:              "paritypr/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "${CI_COMMIT_SHORT_SHA}"
-    PARACHAINS_IMAGE:              "docker.io/parity/synth-wave"
+    PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
     PARACHAINS_IMAGE_TAG:          "master"
     COLLATOR_IMAGE:                "docker.io/paritypr/colander"
     COLLATOR_IMAGE_TAG:            "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,3 +150,4 @@ update-latest-container-image:
     - 'buildah push --format=v2s2 "${PUSH_IMAGE}:${PUSH_IMAGE_TAG}"'
   after_script:
     - buildah logout docker.io
+# dummy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ test-current-latest-container-image:
   tags:
     - parity-simnetscripts
   variables:
-    IMAGE_UNDER_TEST:              "paritytech/simnetscripts"
+    IMAGE_UNDER_TEST:              "docker.io/paritypr/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "latest"
     PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
     PARACHAINS_IMAGE_TAG:          "master"
@@ -91,7 +91,7 @@ test-pr-container-image:
     job:                           build-simnetscripts-image-and-push-temporarly-in-paritypr
   interruptible:                   true
   variables:
-    IMAGE_UNDER_TEST:              "paritypr/simnetscripts"
+    IMAGE_UNDER_TEST:              "docker.io/paritypr/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "${CI_COMMIT_SHORT_SHA}"
     PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
     PARACHAINS_IMAGE_TAG:          "master"
@@ -116,9 +116,9 @@ update-latest-container-image:
   variables:
     <<:                            *global-vars
     UPSTREAM_BUILD_TRIGGER:        ${BUILD_SIMNETSCRIPTS}
-    PR_IMAGE:                      "paritypr/simnetscripts"
+    PR_IMAGE:                      "docker.io/paritypr/simnetscripts"
     PR_IMAGE_TAG:                  "${CI_COMMIT_SHORT_SHA}"           
-    PUSH_IMAGE:                    "paritytech/simnetscripts"
+    PUSH_IMAGE:                    "docker.io/paritypr/simnetscripts"
     PUSH_IMAGE_TAG:                "latest"
   stage:                            update-container-image-latest
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,6 +82,7 @@ test-current-latest-container-image:
         --test-script=../../simnet/testing/parachains/run_tests.sh 
         --image="${PARACHAINS_IMAGE}:${PARACHAINS_IMAGE_TAG}" 
         --image-2="${COLLATOR_IMAGE}:${COLLATOR_IMAGE_TAG}"
+  allow_failure: true
 
 test-pr-container-image:          
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,6 +94,8 @@ test-pr-container-image:
   tags:
     - parity-simnetscripts
   stage:                           test
+  needs:
+    job:                           build-simnetscripts-image-and-push-temporarly-in-paritypr
   interruptible:                   true
   variables:
     IMAGE_UNDER_TEST:              "paritypr/simnetscripts"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:                         &global-vars
 build-simnetscripts-image-and-push-temporarly-in-paritypr:
   variables:
     <<:                            *global-vars
-  image:                           quay.io/podman/stable
+  image:                           quay.io/buildah/stable
   tags:
     - parity-simnetscripts-build
   variables:
@@ -26,26 +26,20 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
     - |
       echo "LOG INFO building container ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}"
       echo "${DOCKER_SIMNET_PASS}" \
-           | podman login --username "${DOCKER_SIMNET_USER}" --password-stdin docker.io
+           | buildah login --username "${DOCKER_SIMNET_USER}" --password-stdin docker.io
       whoami
-      podman info
+      buildah info
       df -h | grep /var/lib/containers
       echo "${GITLAB_DEPLOY_TOKEN}" > .GITLAB_DEPLOY_TOKEN
-      time podman run \
-        --volume .:/build  \
-        --volume /var/lib/containers/:/var/lib/containers \
-        --device /dev/fuse \
-        --privileged   \
-        quay.io/buildah/stable \
-            buildah bud  \
-              --layers=true  \
-              --cache-from  "${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}" \
-              --tag         "${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}" \
-              /build 
+      buildah bud  \
+        --layers=true  \
+        --cache-from  "${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}" \
+        --tag         "${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG}" \
+
       echo "LOG INFO image ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG} built successfully"
       echo "$DOCKER_SIMNET_PASS" \
-           | podman  login --username "$DOCKER_SIMNET_USER" --password-stdin docker.io
-      podman push --format=v2s2 "$CONTAINER_IMAGE:$CONTAINER_IMAGE_TAG"
+           | buildah  login --username "$DOCKER_SIMNET_USER" --password-stdin docker.io
+      buildah push --format=v2s2 "$CONTAINER_IMAGE:$CONTAINER_IMAGE_TAG"
       echo "LOG INFO ${CONTAINER_IMAGE}:${CONTAINER_IMAGE_TAG} pushed successfully"
       echo "LOG check if need to cleanup dangling images"
       df -h | grep /var/lib/containers
@@ -54,13 +48,13 @@ build-simnetscripts-image-and-push-temporarly-in-paritypr:
               || ( echo "This variable can't be emtpy" ; exit 1 )
       if test "${CACHE_USE_PERCENT}" -ge 80 ; then 
         echo "LOG INFO need to cleanup cache, value: ${CACHE_USE_PERCENT}"
-        time podman rmi -f $(podman images -q -f "dangling=true")
+        time buildah rmi -f $(buildah images -q -f "dangling=true")
       else 
         echo "LOG INFO No Cleanup needed this time value: ${CACHE_USE_PERCENT}"
       fi
   retry: 1
   after_script:
-    - podman logout docker.io
+    - buildah logout docker.io
 
 test-current-latest-container-image:
   stage:                           build
@@ -69,11 +63,7 @@ test-current-latest-container-image:
   variables:
     IMAGE_UNDER_TEST:              "paritytech/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "latest"
-    # use parity/polkadot as default until we will have paritypr/synth-wave:master
-    PARACHAINS_IMAGE:              "docker.io/parity/polkadot"
-    # PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
-    # there is no master tag for docker.io/paritypr/synth-wave
-    # Error response from daemon: manifest for paritypr/synth-wave:master not found: manifest unknown: manifest unknown
+    PARACHAINS_IMAGE:              "docker.io/parity/synth-wave"
     PARACHAINS_IMAGE_TAG:          "master"
     COLLATOR_IMAGE:                "docker.io/paritypr/colander"
     COLLATOR_IMAGE_TAG:            "master"
@@ -103,11 +93,7 @@ test-pr-container-image:
   variables:
     IMAGE_UNDER_TEST:              "paritypr/simnetscripts"
     IMAGE_UNDER_TEST_TAG:          "${CI_COMMIT_SHORT_SHA}"
-    # use parity/polkadot as default until we will have paritypr/synth-wave:master
-    PARACHAINS_IMAGE:              "docker.io/parity/polkadot"
-    # PARACHAINS_IMAGE:              "docker.io/paritypr/synth-wave"
-    # there is no master tag for docker.io/paritypr/synth-wave
-    # Error response from daemon: manifest for paritypr/synth-wave:master not found: manifest unknown: manifest unknown
+    PARACHAINS_IMAGE:              "docker.io/parity/synth-wave"
     PARACHAINS_IMAGE_TAG:          "master"
     COLLATOR_IMAGE:                "docker.io/paritypr/colander"
     COLLATOR_IMAGE_TAG:            "master"
@@ -156,4 +142,3 @@ update-latest-container-image:
     - 'buildah push --format=v2s2 "${PUSH_IMAGE}:${PUSH_IMAGE_TAG}"'
   after_script:
     - buildah logout docker.io
-# dummy

--- a/.maintain/k8s-resources/gitlab/build-values.yaml
+++ b/.maintain/k8s-resources/gitlab/build-values.yaml
@@ -383,7 +383,7 @@ securityContext:
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
-resources: {}
+resources:
   limits:
     memory: 2Gi
     cpu: 900m

--- a/.maintain/k8s-resources/gitlab/build-values.yaml
+++ b/.maintain/k8s-resources/gitlab/build-values.yaml
@@ -384,12 +384,12 @@ securityContext:
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
 resources: {}
-  # limits:
-  #   memory: 256Mi
-  #   cpu: 200m
-  # requests:
-  #   memory: 128Mi
-  #   cpu: 100m
+  limits:
+    memory: 2Gi
+    cpu: 900m
+  requests:
+    memory: 1Gi
+    cpu: 500m
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/.maintain/k8s-resources/gitlab/values.yaml
+++ b/.maintain/k8s-resources/gitlab/values.yaml
@@ -30,7 +30,7 @@ gitlabUrl: https://gitlab.parity.io/
 #
 # runnerRegistrationToken: ""
 # simnetscripts
-runnerRegistrationToken: "LiKxi3TkzuAUidwMMizm"
+runnerRegistrationToken: "3d5gGCsqHXBLyxx8wUxf"
 
 ## The Runner Token for adding new Runners to the GitLab Server. This must
 ## be retrieved from your GitLab Instance. It is token of already registered runner.

--- a/.maintain/k8s-resources/gitlab/values.yaml
+++ b/.maintain/k8s-resources/gitlab/values.yaml
@@ -29,9 +29,6 @@ gitlabUrl: https://gitlab.parity.io/
 ##
 #
 # runnerRegistrationToken: ""
-# simnetscripts
-# provide val as cmd arg when the runner is installed
-runnerRegistrationToken: ""
 
 ## The Runner Token for adding new Runners to the GitLab Server. This must
 ## be retrieved from your GitLab Instance. It is token of already registered runner.

--- a/.maintain/k8s-resources/gitlab/values.yaml
+++ b/.maintain/k8s-resources/gitlab/values.yaml
@@ -30,7 +30,8 @@ gitlabUrl: https://gitlab.parity.io/
 #
 # runnerRegistrationToken: ""
 # simnetscripts
-runnerRegistrationToken: "3d5gGCsqHXBLyxx8wUxf"
+# provide val as cmd arg when the runner is installed
+runnerRegistrationToken: ""
 
 ## The Runner Token for adding new Runners to the GitLab Server. This must
 ## be retrieved from your GitLab Instance. It is token of already registered runner.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update --fix-missing && \
-    apt-get install -y nodejs yarn
-
+    apt-get install -y git nodejs yarn
 
 WORKDIR /home/nonroot/simnet_scripts
 
@@ -25,12 +24,17 @@ RUN npm run build
 # place index.js in a place where gurke expects it
 RUN ln -s "$(pwd)"/dist/index.js /usr/local/bin/simnet_scripts
 
+WORKDIR /home/nonroot
+# get content of .GITLAB_DEPLOY_TOKEN from 1password -> Simnet-Team
+COPY .GITLAB_DEPLOY_TOKEN .
+# git clone https://<username>:<deploy_token>@gitlab.example.com/tanuki/awesome_project.git
+RUN git clone https://gitlab+deploy-token-19:$(cat .GITLAB_DEPLOY_TOKEN)@gitlab.parity.io/parity/simnet.git
 RUN chown -R nonroot. /home/nonroot
 
 # Use the non-root user to run our application
 USER nonroot
 
-WORKDIR /home/nonroot/gurke
+WORKDIR /home/nonroot/
 # Tini allows us to avoid several Docker edge cases, see https://github.com/krallin/tini
 ENTRYPOINT ["tini", "--", "bash"]
 # Run your program under Tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /home/nonroot
 COPY .GITLAB_DEPLOY_TOKEN .
 # git clone https://<username>:<deploy_token>@gitlab.example.com/tanuki/awesome_project.git
 RUN git clone https://gitlab+deploy-token-19:$(cat .GITLAB_DEPLOY_TOKEN)@gitlab.parity.io/parity/simnet.git
+RUN rm .GITLAB_DEPLOY_TOKEN
 RUN chown -R nonroot. /home/nonroot
 
 # Use the non-root user to run our application

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN git clone https://gitlab+deploy-token-19:$(cat .GITLAB_DEPLOY_TOKEN)@gitlab.
 RUN chown -R nonroot. /home/nonroot
 
 # Use the non-root user to run our application
+ENV USER nonroot
 USER nonroot
 
 WORKDIR /home/nonroot/

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,2 +1,2 @@
-buuldah bud -t docker.io/paritypr/simnetscripts:latest . && \
+buildah bud -t docker.io/paritypr/simnetscripts:latest . && \
 buuldah push  docker.io/paritypr/simnetscripts:latest 

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,2 +1,2 @@
-docker build -t paritytech/simnetscripts:latest . && \
-docker push  paritytech/simnetscripts:latest 
+buuldah build -t paritytech/simnetscripts:latest . && \
+buuldah push  paritytech/simnetscripts:latest 

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,2 +1,2 @@
 buildah bud -t docker.io/paritypr/simnetscripts:latest . && \
-buuldah push  docker.io/paritypr/simnetscripts:latest 
+buildah push  docker.io/paritypr/simnetscripts:latest 

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,0 +1,2 @@
+docker build -t paritytech/simnetscripts:latest . && \
+docker push  paritytech/simnetscripts:latest 

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,2 +1,2 @@
-buuldah build -t paritytech/simnetscripts:latest . && \
+buuldah bud -t paritytech/simnetscripts:latest . && \
 buuldah push  paritytech/simnetscripts:latest 

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,2 +1,2 @@
-buuldah bud -t paritytech/simnetscripts:latest . && \
-buuldah push  paritytech/simnetscripts:latest 
+buuldah bud -t docker.io/paritypr/simnetscripts:latest . && \
+buuldah push  docker.io/paritypr/simnetscripts:latest 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+docker build -t paritytech/simnetscripts:latest . 

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-buildah bud -t paritytech/simnetscripts:latest . 
+buildah bud -t docker.io/paritypr/simnetscripts:latest . 

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-buildah build -t paritytech/simnetscripts:latest . 
+buildah bud -t paritytech/simnetscripts:latest . 

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-docker build -t paritytech/simnetscripts:latest . 
+buildah build -t paritytech/simnetscripts:latest . 

--- a/commands.sh
+++ b/commands.sh
@@ -5,5 +5,5 @@ docker run --volume /etc/gurke-container:/etc/gurke/  \
            docker.io/paritytech/simnetscripts:latest \
                /home/nonroot/gurke/scripts/run-test-environment-manager.sh  \
                   --test-script=../../simnet/testing/parachains/run_tests.sh \
-                  --image="docker.io/paritypr/synth-wave:2714" \
-                  --image-2="docker.io/paritypr/colander:2714"
+                  --image="docker.io/paritypr/synth-wave:master" \
+                  --image-2="docker.io/paritypr/colander:master"

--- a/commands.sh
+++ b/commands.sh
@@ -3,7 +3,7 @@
 # run local test of what pipelines runs
 docker run --volume /etc/gurke-container:/etc/gurke/  \
            docker.io/paritytech/simnetscripts:latest \
-               gurke/scripts/run-test-environment-manager.sh  \
+               /home/nonroot/gurke/scripts/run-test-environment-manager.sh  \
                   --test-script=../../simnet/testing/parachains/run_tests.sh \
                   --image="docker.io/paritypr/synth-wave:2714" \
                   --image-2="docker.io/paritypr/colander:2714"

--- a/commands.sh
+++ b/commands.sh
@@ -2,7 +2,7 @@
 
 # run local test of what pipelines runs
 docker run --volume /etc/gurke-container:/etc/gurke/  \
-           docker.io/paritytech/simnetscripts:latest \
+           docker.io/paritypr/simnetscripts:latest \
                /home/nonroot/gurke/scripts/run-test-environment-manager.sh  \
                   --test-script=../../simnet/testing/parachains/run_tests.sh \
                   --image="docker.io/paritypr/synth-wave:master" \

--- a/commands.sh
+++ b/commands.sh
@@ -1,0 +1,9 @@
+
+
+# run local test of what pipelines runs
+docker run --volume /etc/gurke-container:/etc/gurke/  \
+           docker.io/paritytech/simnetscripts:latest \
+               gurke/scripts/run-test-environment-manager.sh  \
+                  --test-script=../../simnet/testing/parachains/run_tests.sh \
+                  --image="docker.io/paritypr/synth-wave:2714" \
+                  --image-2="docker.io/paritypr/colander:2714"


### PR DESCRIPTION
Adding description as requested by Denis.
Here I just copied same overall strategy as I made for  "gurke" and "sub-flood", just to be consistent.

The pipeline has 3 stages
stages:
  - build
  - test
  - update-container-image-latest

For a new pr:
  - in build stage I build a new image and in the same time I test "current latest" so you  have the latest status before your changes.
  - the build job, I configured the runner to attach a persistent volume to be used as caching. There is a script that checks  how much space is left in the persistent volume and runs a clean when the storage is 80% full. The build job pushes the pr in `paritypr`
  -  then the pr image is tested.

On merge on master:
  - same process as for PR plus update "latest" container image after the test of  pr image is OK.
  - once the image was updated, I remove the pr image;  this is an idea I would like to revisit because would like to version our docker images and keep pas X versions
  
 